### PR TITLE
4.2.x - lr transformer arch reduce docker size

### DIFF
--- a/mentor_classifier/Dockerfile
+++ b/mentor_classifier/Dockerfile
@@ -1,7 +1,17 @@
 FROM python:3.8-slim
+# for now we need to pre install 
+# cpu-only versions of all the torch pip modules.
+# The problem stmes from that fb doesn't publish 
+# the cpu versions to pypi and then versions of pip
+# after 19.0 don't respect "dependency_links"
+# (e.g. for https://download.pytorch.org/whl/torch_stable.html)
+# in setup.py
+RUN pip3 install \
+	torch==1.9.0+cpu \
+	torchvision==0.10.0+cpu \
+	-f https://download.pytorch.org/whl/torch_stable.html
 WORKDIR /opt/mentor_classifier
 COPY . .
-RUN apt-get update && apt-get install -y git
 RUN pip install .
 WORKDIR /app
 RUN rm -rf /opt/mentor_classifier

--- a/mentor_classifier/mentor_classifier/api.py
+++ b/mentor_classifier/mentor_classifier/api.py
@@ -114,7 +114,7 @@ def mutation_create_user_question(
                 "question": question,
                 "classifierAnswer": answer_id,
                 "classifierAnswerType": answer_type,
-                "confidence": str(confidence),
+                "confidence": float(confidence),
             }
         },
     }

--- a/mentor_classifier/mentor_classifier/arch/lr_transformer/predict.py
+++ b/mentor_classifier/mentor_classifier/arch/lr_transformer/predict.py
@@ -104,7 +104,7 @@ class TransformersQuestionClassifierPrediction(QuestionClassifierPrediction):
             if answer_key in self.mentor.questions_by_answer
             else []
         )
-        return prediction[0], answer_text, answer_media, highest_confidence
+        return prediction[0], answer_text, answer_media, float(highest_confidence)
 
     def __get_offtopic(self) -> Tuple[str, str]:
         try:

--- a/mentor_classifier_api/Dockerfile
+++ b/mentor_classifier_api/Dockerfile
@@ -1,7 +1,16 @@
 FROM python:3.8-slim
 ENV STATUS_URL_FORCE_HTTPS=false
-RUN apt-get update && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
+# for now we need to pre install 
+# cpu-only versions of all the torch pip modules.
+# The problem stmes from that fb doesn't publish 
+# the cpu versions to pypi and then versions of pip
+# after 19.0 don't respect "dependency_links"
+# (e.g. for https://download.pytorch.org/whl/torch_stable.html)
+# in setup.py
+RUN pip3 install \
+	torch==1.9.0+cpu \
+	torchvision==0.10.0+cpu \
+	-f https://download.pytorch.org/whl/torch_stable.html
 ADD requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
 RUN rm /tmp/requirements.txt


### PR DESCRIPTION
Hacky way to reduce docker image sizes. Prior to this change, including `sentence_transformers` would recursively include `transformers` => `torch` and the pytorch libs would include all the GPU code, bloating the docker-image size to ~3.6GB.

For now, the only way I've found to force cpu-only versions of torch is to force it manually in the Dockerfile, e.g. 

```dockerfile
RUN pip3 install \
	torch==1.9.0+cpu \
	torchvision==0.10.0+cpu \
	-f https://download.pytorch.org/whl/torch_stable.html
```

...the underlying problems are that FB doesn't publish the cpu versions of pytorch to pypi *and* modern versions of pip (>19.0), ignore `dependency_links` arg in `setup.py`